### PR TITLE
Enable keyboard access for nav dropdowns with :focus and :focus-within

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -547,6 +547,8 @@ import Settings from "./TemplateComponents/Settings.astro";
       .cs-dropdown {
         position: relative;
         &:hover,
+        &:focus,
+        &:focus-within,
         &.cs-active {
           cursor: pointer;
           .cs-drop-ul {
@@ -708,7 +710,8 @@ import Settings from "./TemplateComponents/Settings.astro";
 
         .cs-li-link {
           &.cs-drop-link {
-            &:hover {
+            &:hover,
+            &:focus {
               background-color: var(--medium);
             }
           }


### PR DESCRIPTION
This update fixes a critical accessibility issue in the navigation dropdowns. Previously, menu items were only accessible via :hover, which excluded keyboard and screen reader users.

Changes include:
- Added :focus and :focus-within states to match existing :hover styles.
- Ensured dropdown menus can be opened and navigated using keyboard.
- Improved overall WCAG compliance for navigation components.

Why:
Enables full keyboard navigation support, improving accessibility and usability for all users.